### PR TITLE
Somatic indel tagging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:20.04
-LABEL maintainer="https://github.com/ming-en-ho/longphase-s"
+LABEL maintainer="https://github.com/CCU-Bioinformatics-Lab/longphase-s"
 LABEL version="1.0.0"
 
 RUN apt-get update && \
@@ -7,7 +7,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* 
 
 WORKDIR /opt/longphase-s
-RUN git clone https://github.com/ming-en-ho/longphase-s.git /opt/longphase-s && \
+RUN git clone https://github.com/CCU-Bioinformatics-Lab/longphase-s.git /opt/longphase-s && \
     autoreconf -i && \
     ./configure && \
     make -j 4 && \

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ installed. If you require setting up a virtual environment, we also
 provide a [Dockerfile](https://github.com/ming-en-ho/longphase-
 s/blob/somatic-develop/Dockerfile). -->
 
-Clone and compile using the following commands, and make sure that the environment has zlib installed. If you require setting up a virtual environment, we also provide a [Dockerfile](https://github.com/ming-en-ho/longphase-s/blob/somatic-develop/Dockerfile).
+Clone and compile using the following commands, and make sure that the environment has zlib installed. If you require setting up a virtual environment, we also provide a [Dockerfile](https://github.com/CCU-Bioinformatics-Lab/longphase-s/blob/somatic-develop/Dockerfile).
 
 ```
-git clone https://github.com/ming-en-ho/longphase-s.git
+git clone https://github.com/CCU-Bioinformatics-Lab/longphase-s.git
 cd longphase-s
 autoreconf -i
 ./configure

--- a/README.md
+++ b/README.md
@@ -176,14 +176,14 @@ longphase-s phase \
 
 
 #### DeepSomatic output support
-If your normal SNP VCF is produced by DeepSomatic, you can enable a built-in pre-processing step that
+If your SNP VCF is produced by DeepSomatic, you can enable a built-in pre-processing step that
 keeps only GERMLINE variants and normalizes the GT field according to VAF before phasing. This is
 triggered by `--deepsomatic_output`.
 
 Example:
 ```
 longphase-s phase \
--s normal_snp_from_deepsomatic.vcf \
+-s snp_from_deepsomatic.vcf \
 -b alignment1.bam \
 -r reference.fasta \
 -t 8 \

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ In addition, the haplotype block of each read is stored in the PS tag (only for 
 longphase-s somatic_haplotag \
 -s phased_normal_snp.vcf \
 -b normal.bam \
---tumor-snp-file tumor_snp.vcf \
+--tumor-snv-file tumor_snv.vcf \
 --tumor-bam-file tumor.bam \
 -r reference.fasta \
 -t 8 \
@@ -147,7 +147,7 @@ This command using tumor-normal pair BAM and VCF files, along with haplotype inf
 longphase-s estimate_purity \
 -s phased_normal_snp.vcf \
 -b normal.bam \
---tumor-snp-file tumor_snp.vcf \
+--tumor-snv-file tumor_snv.vcf \
 --tumor-bam-file tumor.bam \
 -r reference.fasta \
 -t 8 \

--- a/docs/purity_estimation.md
+++ b/docs/purity_estimation.md
@@ -4,7 +4,7 @@ This command using tumor-normal pair BAM and VCF files, along with haplotype inf
 longphase-s estimate_purity \
 -s phased_normal_snp.vcf \
 -b normal.bam \
---tumor-snp-file tumor_snp.vcf \
+--tumor-snv-file tumor_snv.vcf \
 --tumor-bam-file tumor.bam \
 -r reference.fasta \
 -t 8 \
@@ -20,7 +20,7 @@ Usage:  estimate_purity [OPTION] ... READSFILE
 required arguments:
       -s, --snp-file=NAME             input phased normal sample SNP VCF file.
       -b, --bam-file=NAME             input normal sample BAM file.
-      --tumor-snp-file=NAME           input tumor sample SNP VCF file.
+      --tumor-snv-file=NAME           input tumor sample SNV VCF file.
       --tumor-bam-file=NAME           input tumor sample BAM file.
       -r, --reference=NAME            reference FASTA.
 

--- a/docs/somatic_haplotag.md
+++ b/docs/somatic_haplotag.md
@@ -20,7 +20,7 @@ In addition, the haplotype block of each read is stored in the PS tag (only for 
 longphase-s somatic_haplotag \
 -s phased_normal_snp.vcf \
 -b normal.bam \
---tumor-snp-file tumor_snp.vcf \
+--tumor-snv-file tumor_snv.vcf \
 --tumor-bam-file tumor.bam \
 -r reference.fasta \
 -t 8 \
@@ -61,7 +61,7 @@ Usage:  somatic_haplotag [OPTION] ... READSFILE
 required arguments:
       -s, --snp-file=NAME             input normal sample SNP VCF file.
       -b, --bam-file=NAME             input normal sample BAM file.
-      --tumor-snp-file=NAME           input tumor sample SNP VCF file.
+      --tumor-snv-file=NAME           input tumor sample SNV VCF file.
       --tumor-bam-file=NAME           input tumor sample BAM file for somatic haplotag.
       -r, --reference=NAME            reference FASTA.
 
@@ -126,7 +126,7 @@ All other information in the VCF file remains unchanged from the input tumor VCF
 
 ```
 ##longphase_s_version=1.0.0
-##commandline=longphase_s somatic_haplotag -s phased_normal.vcf -b normal.bam --tumor-snp-file 
+##commandline=longphase_s somatic_haplotag -s phased_normal.vcf -b normal.bam --tumor-snv-file 
 tumor.vcf --tumor-bam-file tumor.bam -r GRCh38_no_alt_analysis_set.fasta -t 64 -o tagged_tumor_bam --tagSupplementary -q 20 --output-somatic-vcf
 #CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  SAMPLE
 ```

--- a/src/haplotag/HaplotagLogging.cpp
+++ b/src/haplotag/HaplotagLogging.cpp
@@ -483,3 +483,49 @@ void ReadHpDistriLog::removeNotDeriveByH1andH2pos(const std::vector<std::string>
         }
     }
 }
+
+/**
+ * @brief Write DenseAlt filter log
+ * @param logFileName Output file name
+ * @param chrVec Vector of chromosome names to process
+ * @param chrPosSomaticInfo Map of chromosome to position to somatic data
+ */
+void ReadHpDistriLog::writeDenseAltFilterLog(const std::string logFileName, const std::vector<std::string> &chrVec, const std::map<std::string, std::map<int, SomaticData>> &chrPosSomaticInfo){
+    std::ofstream *denseAltFilterLog=NULL;
+    denseAltFilterLog=new std::ofstream(logFileName);
+
+    if(!denseAltFilterLog->is_open()){
+        std::cerr<< "Fail to open write file: " << logFileName << "\n";
+        exit(1);
+    }else{
+        (*denseAltFilterLog) << "###################################################\n";
+        (*denseAltFilterLog) << "# DenseAlt filter log #\n";
+        (*denseAltFilterLog) << "###################################################\n";
+    }
+    // Write header for DenseAlt filter log
+    (*denseAltFilterLog) << "Chr\t"
+                        << "Pos\t"
+                        << "DenseAltSameCount\n";
+
+    // Process each chromosome and variant position
+    for(auto chr: chrVec){
+        // Check if this chromosome has somatic data
+        auto chrSomaticIter = chrPosSomaticInfo.find(chr);
+        if(chrSomaticIter != chrPosSomaticInfo.end()){
+            // Iterate through each position in this chromosome
+            for(auto posSomaticIter = chrSomaticIter->second.begin(); posSomaticIter != chrSomaticIter->second.end(); posSomaticIter++){
+                int pos = posSomaticIter->first;
+                const SomaticData& somaticData = posSomaticIter->second;
+                
+                // Write chromosome, position, and denseAltSameCount to log
+                (*denseAltFilterLog) << chr << "\t"
+                                    << pos << "\t"
+                                    << somaticData.denseAltSameCount << "\n";
+            }
+        }
+    }
+
+    (*denseAltFilterLog).close();
+    delete denseAltFilterLog;
+    denseAltFilterLog = nullptr;
+}

--- a/src/haplotag/HaplotagLogging.h
+++ b/src/haplotag/HaplotagLogging.h
@@ -145,6 +145,14 @@ class ReadHpDistriLog{
          * @param chrVec Vector of chromosome names to process
          */
         void removeNotDeriveByH1andH2pos(const std::vector<std::string> &chrVec);
+
+        /**
+         * @brief Write DenseAlt filter log
+         * @param logFileName Output file name
+         * @param chrVec Vector of chromosome names to process
+         * @param chrPosSomaticInfo Map of chromosome to position to somatic data
+         */
+        void writeDenseAltFilterLog(const std::string logFileName, const std::vector<std::string> &chrVec, const std::map<std::string, std::map<int, SomaticData>> &chrPosSomaticInfo);
 };
 
 /**

--- a/src/haplotag/HaplotagParsingBam.cpp
+++ b/src/haplotag/HaplotagParsingBam.cpp
@@ -613,7 +613,6 @@ void CigarParser::parsingCigar(
                             }    
 
                         }
-
                         processMatchOperation(length, cigar, i, aln_core_n_cigar, base, isAlt, offset);                        
                     }
                     currentVariantIter++;

--- a/src/haplotag/HaplotagParsingBam.h
+++ b/src/haplotag/HaplotagParsingBam.h
@@ -448,7 +448,7 @@ class CigarParser{
          * 
          * Virtual method for handling match operations
          */
-        virtual void processMatchOperation(int& length, uint32_t* cigar, int& i, int& aln_core_n_cigar, std::string& base){};
+        virtual void processMatchOperation(int& length, uint32_t* cigar, int& i, int& aln_core_n_cigar, std::string& base, bool& isAlt, int& offset){};
         
         /**
          * @brief Process insertion operation (I)
@@ -502,7 +502,7 @@ class CigarParser{
          * 
          * Updates base counts and filtered depth based on mapping quality
          */
-        void countBaseNucleotide(PosBase& posBase, std::string& base, const bam1_t& aln, const float& mpqThreshold);
+        void countBaseNucleotide(PosBase& posBase, std::string& base, const bam1_t& aln, const float& mpqThreshold, bool isAlt);
         
         /**
          * @brief Count deletion bases

--- a/src/haplotag/HaplotagProcess.cpp
+++ b/src/haplotag/HaplotagProcess.cpp
@@ -96,9 +96,9 @@ void HaplotagProcess::setChrVecAndChrLength(){
 }
 
 void HaplotagProcess::setProcessingChromRegion(){
-    if (!params.bamCfg.region.empty()) {
-        auto colonPos = params.bamCfg.region.find(":");
-        std::string regionChr;
+    if (!params.bamCfg.region.empty()) {//if the region is not empty, set the chromosome vector to the region
+        auto colonPos = params.bamCfg.region.find(":");//find the colon position
+        std::string regionChr;//the chromosome name
         if (colonPos != std::string::npos) {
             regionChr = params.bamCfg.region.substr(0, colonPos);
         }
@@ -136,7 +136,7 @@ void HaplotagProcess::tagRead(HaplotagParameters &params, std::string& tagBamFil
 
     ParsingBamControl control;
     control.mode = ParsingBamMode::SINGLE_THREAD;
-    control.writeOutputBam = true;
+    control.writeOutputBam = false;//////////
     control.mappingQualityFilter = true;
 
     BamParserContext ctx(tagBamFile, params.fastaFile, *chrVec, *chrLength, *chrMultiVariants, vcfSet, geneSample);
@@ -483,9 +483,10 @@ GermlineHaplotagCigarParser::~GermlineHaplotagCigarParser(){
 
 }
 
-void GermlineHaplotagCigarParser::processMatchOperation(int& length, uint32_t* cigar, int& i, int& aln_core_n_cigar, std::string& base){
-    auto norVar = (*currentVariantIter).second.Variant[NORMAL];
-    judger.judgeSnpHap(ctx.chrName, norVar, base, ref_pos, length, i, aln_core_n_cigar, cigar, currentVariantIter, *hpCount, *variantsHP, *norCountPS);
+void GermlineHaplotagCigarParser::processMatchOperation(int& length, uint32_t* cigar, int& i, int& aln_core_n_cigar, std::string& base, bool& isAlt, int& offset){
+    auto norVar = (*currentVariantIter).second.Variant[NORMAL];//get the current normal variant
+    judger.judgeSnpHap(ctx.chrName, norVar, base, ref_pos, length, i, aln_core_n_cigar, cigar, currentVariantIter, *hpCount, *variantsHP, *norCountPS, isAlt);
+    //judge the haplotype of the current normal variant
 }
 
 void GermlineHaplotagCigarParser::processDeletionOperation(int& length, uint32_t* cigar, int& i, int& aln_core_n_cigar, bool& alreadyJudgeDel){

--- a/src/haplotag/HaplotagProcess.cpp
+++ b/src/haplotag/HaplotagProcess.cpp
@@ -136,7 +136,7 @@ void HaplotagProcess::tagRead(HaplotagParameters &params, std::string& tagBamFil
 
     ParsingBamControl control;
     control.mode = ParsingBamMode::SINGLE_THREAD;
-    control.writeOutputBam = false;
+    control.writeOutputBam = true;
     control.mappingQualityFilter = true;
 
     BamParserContext ctx(tagBamFile, params.fastaFile, *chrVec, *chrLength, *chrMultiVariants, vcfSet, geneSample);

--- a/src/haplotag/HaplotagProcess.cpp
+++ b/src/haplotag/HaplotagProcess.cpp
@@ -136,7 +136,7 @@ void HaplotagProcess::tagRead(HaplotagParameters &params, std::string& tagBamFil
 
     ParsingBamControl control;
     control.mode = ParsingBamMode::SINGLE_THREAD;
-    control.writeOutputBam = false;//////////
+    control.writeOutputBam = false;
     control.mappingQualityFilter = true;
 
     BamParserContext ctx(tagBamFile, params.fastaFile, *chrVec, *chrLength, *chrMultiVariants, vcfSet, geneSample);

--- a/src/haplotag/HaplotagProcess.h
+++ b/src/haplotag/HaplotagProcess.h
@@ -84,7 +84,7 @@ class GermlineHaplotagCigarParser: public CigarParser{
     private:
     protected:
         GermlineHaplotagStrategy judger;
-        void processMatchOperation(int& length, uint32_t* cigar, int& i, int& aln_core_n_cigar, std::string& base) override;
+        void processMatchOperation(int& length, uint32_t* cigar, int& i, int& aln_core_n_cigar, std::string& base, bool& isAlt, int& offset) override;
         void processDeletionOperation(int& length, uint32_t* cigar, int& i, int& aln_core_n_cigar, bool& alreadyJudgeDel) override;
     public:
         GermlineHaplotagCigarParser(CigarParserContext& ctx, int& ref_pos, int& query_pos);

--- a/src/haplotag/HaplotagStrategy.cpp
+++ b/src/haplotag/HaplotagStrategy.cpp
@@ -29,16 +29,17 @@ void GermlineHaplotagStrategy::judgeSnpHap(
     std::map<int, MultiGenomeVar>::iterator &currentVariantIter,
     std::map<int, int>& hpCount,
     std::map<int, int>& variantsHP,
-    std::map<int, int>& countPS
+    std::map<int, int>& countPS,
+    bool& isAlt
 ){
     int curPos = (*currentVariantIter).first;
 
     // currentVariant is SNP
-    if( norVar.variantType == VariantType::SNP ){
+    if( norVar.variantType == VariantType::SNP){
         // Detected that the base of the read is either REF or ALT. 
-        if( (base == norVar.allele.Ref) || (base == norVar.allele.Alt) ){
+        if( (base == norVar.allele.Ref) || (base == norVar.allele.Alt) ){//if the base of the read is either REF or ALT
 
-
+            //std::cout << "base: " << base << " norVar.allele.Ref: " << norVar.allele.Ref << " norVar.allele.Alt: " << norVar.allele.Alt << std::endl;
             if(!norVar.isExistPhasedSet()){
                 std::cerr << "[ERROR] (judgeSnpHap) => can't find the position:" 
                           << " chr: " << chrName << "\t"
@@ -63,10 +64,10 @@ void GermlineHaplotagStrategy::judgeSnpHap(
     }
     // currentVariant is insertion
     else if( norVar.variantType == VariantType::INSERTION && i+1 < aln_core_n_cigar){
+
         
         int hp1Length = norVar.HP1.length();
         int hp2Length = norVar.HP2.length();
-        
         if ( ref_pos + length - 1 == (*currentVariantIter).first && bam_cigar_op(cigar[i+1]) == 1 ) {
             // hp1 occur insertion
             if( hp1Length != 1 && hp2Length == 1 ){
@@ -95,6 +96,7 @@ void GermlineHaplotagStrategy::judgeSnpHap(
     } 
     // currentVariant is deletion
     else if( norVar.variantType == VariantType::DELETION && i+1 < aln_core_n_cigar) {
+
 
         int hp1Length = norVar.HP1.length();
         int hp2Length = norVar.HP2.length();
@@ -310,7 +312,7 @@ int GermlineHaplotagStrategy::judgeReadHap(
  * 
  * Determines haplotype assignment for SNPs in somatic samples
  */
-void SomaticJudgeHapStrategy::judgeSomaticSnpHap(std::map<int, MultiGenomeVar>::iterator &currentVariantIter, std::string chrName, std::string base, std::map<int, int> &hpCount, std::map<int, int> &norCountPS, std::map<int, int> &tumCountPS, std::map<int, int> *variantsHP, std::vector<int> *tumorAllelePosVec){
+void SomaticJudgeHapStrategy::judgeSomaticSnpHap(std::map<int, MultiGenomeVar>::iterator &currentVariantIter, std::string chrName, std::string base, std::map<int, int> &hpCount, std::map<int, int> &norCountPS, std::map<int, int> &tumCountPS, std::map<int, int> *variantsHP, std::vector<int> *tumorAllelePosVec, bool& isAlt){
     int curPos = (*currentVariantIter).first;
     auto& curVar = (*currentVariantIter).second;
 
@@ -344,24 +346,52 @@ void SomaticJudgeHapStrategy::judgeSomaticSnpHap(std::map<int, MultiGenomeVar>::
     }else if(curVar.isExists(TUMOR)){
         //the tumor SNP GT is phased heterozygous
         if(curVar.Variant[TUMOR].GT == GenomeType::PHASED_HETERO){
-            if(curVar.Variant[TUMOR].allele.Ref == base || curVar.Variant[TUMOR].allele.Alt == base){
+            if(curVar.Variant[TUMOR].allele.Ref == base || curVar.Variant[TUMOR].allele.Alt == base || curVar.Variant[TUMOR].variantType == VariantType::DELETION 
+                || curVar.Variant[TUMOR].variantType == VariantType::INSERTION){
                 if(!curVar.Variant[TUMOR].isExistPhasedSet()){
                     std::cerr<< curPos << "\t"
                              << curVar.Variant[TUMOR].allele.Ref << "\t"
                              << curVar.Variant[TUMOR].allele.Alt << "\n";
                     exit(EXIT_SUCCESS);
                 }else{
+                    if(curVar.Variant[TUMOR].variantType == VariantType::DELETION || curVar.Variant[TUMOR].variantType == VariantType::INSERTION){
+                        if(isAlt){
+                            base = curVar.Variant[TUMOR].allele.Alt;
+                        }
+                        else{
+                            base = curVar.Variant[TUMOR].allele.Ref;
+                        }
+                    }
                     judgeTumorOnlySnpHap(chrName, curPos, curVar, base, hpCount, &tumCountPS, variantsHP, tumorAllelePosVec);
                 }
             }
         //the tumor SNP GT is unphased heterozygous
         }else if(curVar.Variant[TUMOR].GT == GenomeType::UNPHASED_HETERO){
-            if(curVar.Variant[TUMOR].allele.Ref == base || curVar.Variant[TUMOR].allele.Alt == base){
+            if(curVar.Variant[TUMOR].allele.Ref == base || curVar.Variant[TUMOR].allele.Alt == base || curVar.Variant[TUMOR].variantType == VariantType::DELETION 
+                || curVar.Variant[TUMOR].variantType == VariantType::INSERTION){
+                if(curVar.Variant[TUMOR].variantType == VariantType::DELETION || curVar.Variant[TUMOR].variantType == VariantType::INSERTION){
+                    if(isAlt){
+                        base = curVar.Variant[TUMOR].allele.Alt;
+                    }
+                    else{
+                        base = curVar.Variant[TUMOR].allele.Ref;
+                    }
+                }
+                // //std::cout <<curVar.Variant[TUMOR].variantType<< "curPos: " << curPos << " alt: " << curVar.Variant[TUMOR].allele.Alt << " ref: " << curVar.Variant[TUMOR].allele.Ref << " base: " << base << std::endl;
                 judgeTumorOnlySnpHap(chrName, curPos, curVar, base, hpCount, nullptr, variantsHP, tumorAllelePosVec);
             }           
         //the tumor SNP GT is homozygous
         }else if(curVar.Variant[TUMOR].GT == GenomeType::UNPHASED_HOMO){
-            if(curVar.Variant[TUMOR].allele.Ref == base || curVar.Variant[TUMOR].allele.Alt == base){
+            if(curVar.Variant[TUMOR].allele.Ref == base || curVar.Variant[TUMOR].allele.Alt == base || curVar.Variant[TUMOR].variantType == VariantType::DELETION 
+                || curVar.Variant[TUMOR].variantType == VariantType::INSERTION){
+                if(curVar.Variant[TUMOR].variantType == VariantType::DELETION || curVar.Variant[TUMOR].variantType == VariantType::INSERTION){
+                    if(isAlt){
+                        base = curVar.Variant[TUMOR].allele.Alt;
+                    }
+                    else{
+                        base = curVar.Variant[TUMOR].allele.Ref;
+                    }
+                }
                 judgeTumorOnlySnpHap(chrName, curPos, curVar, base, hpCount, nullptr, variantsHP, tumorAllelePosVec);
             }
         }
@@ -600,14 +630,14 @@ void ExtractSomaticDataStragtegy::judgeTumorOnlySnpHap(const std::string &chrNam
         std::cerr << "[ERROR] (SomaticDetectJudgeHP) => tumorAllelePosVec pointer cannot be nullptr"<< std::endl;
         exit(1);
     }
-
+    
     std::string& TumorRefBase = curVar.Variant[TUMOR].allele.Ref;
     std::string& TumorAltBase = curVar.Variant[TUMOR].allele.Alt; 
     
     if(base == TumorAltBase){
         hpCount[3]++;
         if(variantsHP != nullptr) (*variantsHP)[curPos] = SnpHP::SOMATIC_H3;
-
+        //std::cout << "curPos: " << curPos << " base: " << base << " TumorAltBase: " << TumorAltBase << std::endl;
         //record postions that tagged as HP3 for calculating the confidence of somatic positions
         (*tumorAllelePosVec).push_back(curPos);
     }else if(base != TumorRefBase && base != TumorAltBase){
@@ -634,8 +664,9 @@ void SomaticHaplotagStrategy::judgeTumorOnlySnpHap(const std::string &chrName, i
 
     if(curVar.isSomaticVariant){
         std::string& TumorAltBase = curVar.Variant[TUMOR].allele.Alt; 
-
+        //std::cout << "curPos: " << curPos << " base: " << base << " TumorAltBase: " << TumorAltBase << std::endl;
         if(base == TumorAltBase){
+            
             hpCount[3]++;
             if(variantsHP != nullptr) (*variantsHP)[curPos] = SnpHP::SOMATIC_H3;
         }

--- a/src/haplotag/HaplotagStrategy.cpp
+++ b/src/haplotag/HaplotagStrategy.cpp
@@ -315,31 +315,21 @@ int GermlineHaplotagStrategy::judgeReadHap(
 void SomaticJudgeHapStrategy::judgeSomaticSnpHap(std::map<int, MultiGenomeVar>::iterator &currentVariantIter, std::string chrName, std::string base, std::map<int, int> &hpCount, std::map<int, int> &norCountPS, std::map<int, int> &tumCountPS, std::map<int, int> *variantsHP, std::vector<int> *tumorAllelePosVec, bool& isAlt){
     int curPos = (*currentVariantIter).first;
     auto& curVar = (*currentVariantIter).second;
-
     // normal & tumor SNP at the current position (base on normal phased SNPs)
     // both normal and tumor samples that do not exist in the high-confidence set
-    if(curVar.isExists(NORMAL) && curVar.isExists(TUMOR)){
-        // the tumor & normal SNP GT are phased heterozygous 
-        if((curVar.Variant[NORMAL].GT == GenomeType::PHASED_HETERO) && 
-            (curVar.Variant[TUMOR].GT == GenomeType::PHASED_HETERO)){ 
-            judgeNormalSnpHap(chrName, curPos, curVar, base, hpCount, norCountPS, variantsHP);
-
-        }
-        //the normal SNP GT is phased heterozgous & the tumor SNP GT is unphased heterozgous 
-        else if((curVar.Variant[NORMAL].GT == GenomeType::PHASED_HETERO) && 
-                (curVar.Variant[TUMOR].GT == GenomeType::UNPHASED_HETERO)){   
-            judgeNormalSnpHap(chrName, curPos, curVar, base, hpCount, norCountPS, variantsHP);
-
-        }
-        //the normal SNP GT is phased heterozgous & the tumor SNP GT is homozygous 
-        else if((curVar.Variant[NORMAL].GT == GenomeType::PHASED_HETERO) && 
-                (curVar.Variant[TUMOR].GT == GenomeType::UNPHASED_HOMO)){ 
-            judgeNormalSnpHap(chrName, curPos, curVar, base, hpCount, norCountPS, variantsHP);
-        }
+   
     // only normal SNP at the current position
-    }else if(curVar.isExists(NORMAL)){
+    if(curVar.isExists(NORMAL)){
         // the normal SNP GT is phased heterozgous SNP
         if((curVar.Variant[NORMAL].GT == GenomeType::PHASED_HETERO)){
+            if(curVar.Variant[NORMAL].variantType == VariantType::DELETION || curVar.Variant[NORMAL].variantType == VariantType::INSERTION){
+                if(isAlt){
+                    base = curVar.Variant[NORMAL].allele.Alt;
+                }
+                else{
+                    base = curVar.Variant[NORMAL].allele.Ref;
+                }
+            }
             judgeNormalSnpHap(chrName, curPos, curVar, base, hpCount, norCountPS, variantsHP);
         }
     // only tumor SNP at the current position

--- a/src/haplotag/HaplotagStrategy.h
+++ b/src/haplotag/HaplotagStrategy.h
@@ -23,7 +23,8 @@ class GermlineHaplotagStrategy{
             std::map<int, MultiGenomeVar>::iterator& currentVariantIter,
             std::map<int, int>& hpCount,
             std::map<int, int>& variantsHP,
-            std::map<int, int>& countPS
+            std::map<int, int>& countPS,
+            bool& isAlt
         );
 
         void judgeDeletionHap(
@@ -96,7 +97,8 @@ class SomaticJudgeHapStrategy{
             std::map<int, int> &norCountPS,
             std::map<int, int> &tumCountPS,
             std::map<int, int> *variantsHP,
-            std::vector<int> *tumorAllelePosVec
+            std::vector<int> *tumorAllelePosVec,
+            bool& isAlt
         );
 
 

--- a/src/haplotag/HaplotagType.h
+++ b/src/haplotag/HaplotagType.h
@@ -263,20 +263,33 @@ struct SomaticData{
     int intervalSnpCount;
     int minDistance;
     bool inDenseTumorInterval;
+
+    // dense alt filter information
+    int denseAltSameCount;
+    
+    // per-filter flags (somatic feature filter)
+    bool filteredByTINC;
+    bool filteredByMessyRead;
+    bool filteredByReadCount;
+    bool filteredByHapConsistency;
+    bool filteredByVariantCluster;
+    bool filteredByDenseAlt;
     
     // filter out by somatic feature filter
     bool isFilterOut;
-
+  
     //readHp, count
     std::map<int, int> somaticReadHpCount;
     std::array<std::vector<std::pair<int, char>>, 2> PosSomaticOffsetBase;//0: ref, 1: alt
-
+    std::array<int, 2> alleleCount;//0: ref, 1: alt
     SomaticData(): totalCleanHP3Read(0), pure_H1_1_read(0), pure_H2_1_read(0), pure_H3_read(0), Mixed_HP_read(0), unTag(0)
              , CaseReadCount(0), pure_H1_1_readRatio(0.0), pure_H2_1_readRatio(0.0), pure_H3_readRatio(0.0), Mixed_HP_readRatio(0.0)
              , base(), GTtype(""), somaticHp4Base(Nitrogenous::UNKOWN), somaticHp5Base(Nitrogenous::UNKOWN), somaticHp4BaseCount(0), somaticHp5BaseCount(0)
              , isHighConSomaticSNP(false), somaticReadDeriveByHP(0), shannonEntropy(0.0), homopolymerLength(0)
              , statisticPurity(false), allelicImbalanceRatio(0.0), somaticHaplotypeImbalanceRatio(0.0)
              , meanAltCountPerVarRead(0.0), zScore(0.0), intervalSnpCount(0), minDistance(0), inDenseTumorInterval(false)
+             , denseAltSameCount(0)
+             , filteredByTINC(false), filteredByMessyRead(false), filteredByReadCount(false), filteredByHapConsistency(false), filteredByVariantCluster(false), filteredByDenseAlt(false)
              , isFilterOut(false), somaticReadHpCount(std::map<int, int>()), PosSomaticOffsetBase({std::vector<std::pair<int, char>>(), std::vector<std::pair<int, char>>()}){}
 };
 

--- a/src/haplotag/HaplotagType.h
+++ b/src/haplotag/HaplotagType.h
@@ -19,6 +19,18 @@ enum HaplotagOption
     CRAM
 };
 
+enum CIGAR_OP {
+    CIGAR_MATCH = 0,     // alignment match (can be a sequence match or mismatch)
+    CIGAR_INSERTION = 1, // insertion to the reference
+    CIGAR_DELETION = 2,  // deletion from the reference
+    CIGAR_SKIP = 3,      // skipped region from the reference
+    CIGAR_SOFT_CLIP = 4, // soft clipping
+    CIGAR_HARD_CLIP = 5, // hard clipping
+    CIGAR_N = 6,         // skipped region of unknown type
+    CIGAR_EQ = 7,        // sequence match
+    CIGAR_X = 8,         // sequence mismatch
+};
+
 enum SomaticHaplotagOption
 {
     TUM_SNP = 50,
@@ -30,6 +42,12 @@ enum SomaticHaplotagOption
     BENCHMARK_VCF,
     BENCHMARK_BED,
     BENCHMARK_LOG
+};
+
+enum Allele {
+    Allele_UNDEFINED = -1,
+    REF_ALLELE = 0,
+    ALT_ALLELE = 1
 };
 
 enum Genome
@@ -56,7 +74,7 @@ enum Nitrogenous
     T = 4,
 };
 
-enum VariantType
+enum class VariantType
 {
     NONE_VAR = 0,
     SNP = 1,
@@ -145,6 +163,8 @@ struct MultiGenomeVar{
 
 //record each type of base in specific position
 struct PosBase{
+
+    int altCount;
     int A_count;
     int C_count;
     int G_count;
@@ -153,6 +173,7 @@ struct PosBase{
     int depth;
     int delCount;
 
+    int MPQ_altCount;
     int MPQ_A_count;
     int MPQ_C_count;
     int MPQ_G_count;
@@ -173,8 +194,8 @@ struct PosBase{
     //snp position, read hp count
     std::map<int, int> ReadHpCount;
     
-    PosBase(): A_count(0), C_count(0), G_count(0), T_count(0), unknow(0), depth(0), delCount(0)
-             , MPQ_A_count(0), MPQ_C_count(0), MPQ_G_count(0), MPQ_T_count(0), MPQ_unknow(0), filteredMpqDepth(0) 
+    PosBase(): altCount(0), A_count(0), C_count(0), G_count(0), T_count(0), unknow(0), depth(0), delCount(0)
+             , MPQ_altCount(0), MPQ_A_count(0), MPQ_C_count(0), MPQ_G_count(0), MPQ_T_count(0), MPQ_unknow(0), filteredMpqDepth(0) 
              , VAF(0.0), nonDelVAF(0.0), filteredMpqVAF(0.0), lowMpqReadRatio(0.0), delRatio(0.0)
              , germlineHaplotypeImbalanceRatio(0.0), percentageOfGermlineHp(0.0)
              , ReadHpCount(std::map<int, int>()){}
@@ -186,6 +207,9 @@ struct PosBase{
         if (base == "G") return G_count;
         throw std::runtime_error("(getBaseCount)Invalid base: " + base);
     }
+    int getAltCount() const {
+        return altCount;
+    }
 
     int getMpqBaseCount(const std::string& base) const {
         if (base == "A") return MPQ_A_count;
@@ -193,6 +217,9 @@ struct PosBase{
         if (base == "C") return MPQ_C_count;
         if (base == "G") return MPQ_G_count;
         throw std::runtime_error("(getMpqBaseCount)Invalid base: " + base);
+    }
+    int getMpqAltCount() const {
+        return MPQ_altCount;
     }
 };
 
@@ -242,6 +269,7 @@ struct SomaticData{
 
     //readHp, count
     std::map<int, int> somaticReadHpCount;
+    std::array<std::vector<std::pair<int, char>>, 2> PosSomaticOffsetBase;//0: ref, 1: alt
 
     SomaticData(): totalCleanHP3Read(0), pure_H1_1_read(0), pure_H2_1_read(0), pure_H3_read(0), Mixed_HP_read(0), unTag(0)
              , CaseReadCount(0), pure_H1_1_readRatio(0.0), pure_H2_1_readRatio(0.0), pure_H3_readRatio(0.0), Mixed_HP_readRatio(0.0)
@@ -249,7 +277,7 @@ struct SomaticData{
              , isHighConSomaticSNP(false), somaticReadDeriveByHP(0), shannonEntropy(0.0), homopolymerLength(0)
              , statisticPurity(false), allelicImbalanceRatio(0.0), somaticHaplotypeImbalanceRatio(0.0)
              , meanAltCountPerVarRead(0.0), zScore(0.0), intervalSnpCount(0), minDistance(0), inDenseTumorInterval(false)
-             , isFilterOut(false), somaticReadHpCount(std::map<int, int>()){}
+             , isFilterOut(false), somaticReadHpCount(std::map<int, int>()), PosSomaticOffsetBase({std::vector<std::pair<int, char>>(), std::vector<std::pair<int, char>>()}){}
 };
 
 //record vcf information

--- a/src/haplotag/HaplotagVcfParser.cpp
+++ b/src/haplotag/HaplotagVcfParser.cpp
@@ -531,7 +531,7 @@ void VcfParser::writeProcess(std::string &input, VCF_Info &Info, std::map<std::s
                     auto varIt = posIt->second.Variant.find(TUMOR);
                     if (varIt != posIt->second.Variant.end()) {
                         // Only process SNPs for somatic variant calling
-                        if(varIt->second.variantType == VariantType::SNP){
+                        if(varIt->second.variantType == VariantType::SNP || varIt->second.variantType == VariantType::INSERTION || varIt->second.variantType == VariantType::DELETION){
                             // Update FILTER field based on somatic status
                             if (posIt->second.isSomaticVariant) {
                                 if (fields[6] != "PASS") {

--- a/src/somatic_haplotag/PurityEstimation.cpp
+++ b/src/somatic_haplotag/PurityEstimation.cpp
@@ -8,7 +8,7 @@ constexpr const char *CORRECT_USAGE_MESSAGE =
 "required arguments:\n"
 "      -s, --snp-file=NAME             input phased normal sample SNP VCF file.\n"
 "      -b, --bam-file=NAME             input normal sample BAM file.\n"
-"      --tumor-snp-file=NAME           input tumor sample SNP VCF file.\n"
+"      --tumor-snv-file=NAME           input tumor sample SNV VCF file.\n"
 "      --tumor-bam-file=NAME           input tumor sample BAM file.\n"
 "      -r, --reference=NAME            reference FASTA.\n\n"
 "optional arguments:\n"
@@ -28,7 +28,7 @@ void PurityEstimOptDefiner::defineOptions(ArgumentManager& manager) {
     HaplotagOptionDefiner::defineOptions(manager);
 
     // somatic haplotag-specific options
-    manager.addOption({"tumor-snp-file", required_argument, NULL, TUM_SNP});
+    manager.addOption({"tumor-snv-file", required_argument, NULL, TUM_SNP});
     manager.addOption({"tumor-bam-file", required_argument, NULL, TUM_BAM});
 }
 
@@ -49,7 +49,7 @@ bool ParamsHandler<PurityEstimParameters>::loadArgument(PurityEstimParameters& p
         //load somatic haplotag options
         switch (opt)
         {
-            case SomaticHaplotagOption::TUM_SNP: arg >> params.tumorSnpFile; break;
+            case SomaticHaplotagOption::TUM_SNP: arg >> params.tumorSnvFile; break;
             case SomaticHaplotagOption::TUM_BAM: arg >> params.tumorBamFile; break;
             default: isLoaded = false; 
             break;
@@ -62,7 +62,7 @@ bool ParamsHandler<PurityEstimParameters>::validateFiles(PurityEstimParameters& 
     // validate base haplotag files
     bool isValid = ParamsHandler<HaplotagParameters>::validateFiles(params.basic, programName);
     // validate somatic haplotag files
-    isValid &= FileValidator::validateRequiredFile(params.tumorSnpFile, "tumor SNP file", programName);
+    isValid &= FileValidator::validateRequiredFile(params.tumorSnvFile, "tumor SNV file", programName);
     isValid &= FileValidator::validateRequiredFile(params.tumorBamFile, "tumor BAM file", programName);
     return isValid;
 }

--- a/src/somatic_haplotag/PurityEstimationProcess.cpp
+++ b/src/somatic_haplotag/PurityEstimationProcess.cpp
@@ -14,7 +14,7 @@ void PurityEstimProcess::printParamsMessage() {
     std::cerr<< "\n";
     std::cerr<< "[Input Files]\n";
     std::cerr<< "phased normal SNP file       : " << params.basic.snpFile << "\n";
-    std::cerr<< "tumor SNP file               : " << params.tumorSnpFile << "\n";
+    std::cerr<< "tumor SNP file               : " << params.tumorSnvFile << "\n";
     std::cerr<< "normal BAM file              : " << params.basic.bamFile << "\n";
     std::cerr<< "tumor BAM file               : " << params.tumorBamFile << "\n";
     std::cerr<< "reference file               : " << params.basic.fastaFile << "\n\n";
@@ -36,11 +36,11 @@ void PurityEstimProcess::parseVariantFiles(VcfParser& vcfParser) {
     HaplotagProcess::parseVariantFiles(vcfParser);
 
     //load tumor snp vcf
-    if(params.tumorSnpFile != ""){
+    if(params.tumorSnvFile != ""){
         std::time_t begin = time(NULL);
         std::cerr<< "parsing tumor SNP VCF ... ";
         vcfParser.setParseSnpFile(true);
-        vcfParser.parsingVCF(params.tumorSnpFile, vcfSet[Genome::TUMOR], *chrMultiVariants);
+        vcfParser.parsingVCF(params.tumorSnvFile, vcfSet[Genome::TUMOR], *chrMultiVariants);
         vcfParser.reset();
         std::cerr<< difftime(time(NULL), begin) << "s\n";
     }

--- a/src/somatic_haplotag/PurityEstimationProcess.h
+++ b/src/somatic_haplotag/PurityEstimationProcess.h
@@ -9,7 +9,7 @@ struct PurityEstimParameters
 {
     HaplotagParameters basic;
     std::string tumorBamFile;
-    std::string tumorSnpFile;
+    std::string tumorSnvFile;
 };
 
 class PurityEstimProcess : public HaplotagProcess {

--- a/src/somatic_haplotag/SomaticHaplotag.cpp
+++ b/src/somatic_haplotag/SomaticHaplotag.cpp
@@ -8,7 +8,7 @@ constexpr const char *CORRECT_USAGE_MESSAGE =
 "required arguments:\n"
 "      -s, --snp-file=NAME             input phased normal sample SNP VCF file.\n"
 "      -b, --bam-file=NAME             input normal sample BAM file.\n"
-"      --tumor-snp-file=NAME           input tumor sample SNP VCF file.\n"
+"      --tumor-snv-file=NAME           input tumor sample SNV VCF file.\n"
 "      --tumor-bam-file=NAME           input tumor sample BAM file for somatic haplotag.\n"
 "      -r, --reference=NAME            reference FASTA.\n\n"
 "optional arguments:\n"
@@ -42,7 +42,7 @@ void SomaticHaplotagOptionDefiner::defineOptions(ArgumentManager& manager) {
     HaplotagOptionDefiner::defineOptions(manager);
 
     // somatic haplotag-specific options
-    manager.addOption({"tumor-snp-file", required_argument, NULL, TUM_SNP});
+    manager.addOption({"tumor-snv-file", required_argument, NULL, TUM_SNP});
     manager.addOption({"tumor-bam-file", required_argument, NULL, TUM_BAM});
     
     manager.addOption({"disableFilter", no_argument, NULL, DISABLE_FILTER});
@@ -78,7 +78,7 @@ bool ParamsHandler<SomaticHaplotagParameters>::loadArgument(SomaticHaplotagParam
         //load somatic haplotag options
         switch (opt)
         {
-            case SomaticHaplotagOption::TUM_SNP: arg >> params.tumorSnpFile; break;
+            case SomaticHaplotagOption::TUM_SNP: arg >> params.tumorSnvFile; break;
             case SomaticHaplotagOption::TUM_BAM: arg >> params.tumorBamFile; break;
             case SomaticHaplotagOption::BENCHMARK_VCF: arg >> params.benchmarkVcf; break;
             case SomaticHaplotagOption::BENCHMARK_BED: arg >> params.benchmarkBedFile; break;
@@ -101,7 +101,7 @@ bool ParamsHandler<SomaticHaplotagParameters>::validateFiles(SomaticHaplotagPara
     // validate base haplotag files
     bool isValid = ParamsHandler<HaplotagParameters>::validateFiles(params.basic, programName);
     // validate somatic haplotag files
-    isValid &= FileValidator::validateRequiredFile(params.tumorSnpFile, "tumor SNP file", programName);
+    isValid &= FileValidator::validateRequiredFile(params.tumorSnvFile, "tumor SNV file", programName);
     isValid &= FileValidator::validateRequiredFile(params.tumorBamFile, "tumor BAM file", programName);
     isValid &= FileValidator::validateOptionalFile(params.benchmarkVcf, "benchmark VCF file", programName);
     isValid &= FileValidator::validateOptionalFile(params.benchmarkBedFile, "benchmark BED file", programName);

--- a/src/somatic_haplotag/SomaticHaplotagProcess.cpp
+++ b/src/somatic_haplotag/SomaticHaplotagProcess.cpp
@@ -97,6 +97,7 @@ void SomaticHaplotagProcess::pipelineProcess()
         // somaticBenchmark.displayBedRegionCount(*chrVec);
     }
 
+
     // tag read
     tagRead(sParams.basic, sParams.tumorBamFile, tagSample);
 

--- a/src/somatic_haplotag/SomaticHaplotagProcess.cpp
+++ b/src/somatic_haplotag/SomaticHaplotagProcess.cpp
@@ -97,7 +97,7 @@ void SomaticHaplotagProcess::pipelineProcess()
         // somaticBenchmark.displayBedRegionCount(*chrVec);
     }
 
-    // return;
+    return;
     // tag read
     tagRead(sParams.basic, sParams.tumorBamFile, tagSample);
 

--- a/src/somatic_haplotag/SomaticHaplotagProcess.cpp
+++ b/src/somatic_haplotag/SomaticHaplotagProcess.cpp
@@ -18,7 +18,7 @@ void SomaticHaplotagProcess::printParamsMessage(){
     std::cerr<< "\n";
     std::cerr<< "[Input Files]\n";
     std::cerr<< "phased normal SNP file       : " << sParams.basic.snpFile << "\n";
-    std::cerr<< "tumor SNP file               : " << sParams.tumorSnpFile << "\n";
+    std::cerr<< "tumor SNP file               : " << sParams.tumorSnvFile << "\n";
     std::cerr<< "normal BAM file              : " << sParams.basic.bamFile << "\n";
     std::cerr<< "tumor BAM file               : " << sParams.tumorBamFile << "\n";
     std::cerr<< "reference file               : " << sParams.basic.fastaFile << "\n";
@@ -69,7 +69,7 @@ void SomaticHaplotagProcess::pipelineProcess()
 
     //somatic variant calling
     CallerContext ctx(sParams.basic.bamFile, sParams.tumorBamFile, 
-                    sParams.basic.snpFile, sParams.tumorSnpFile, 
+                    sParams.basic.snpFile, sParams.tumorSnvFile, 
                     sParams.basic.fastaFile);
 
     SomaticVarCaller *somaticVarCaller = new SomaticVarCaller(sParams.callerCfg, sParams.basic.bamCfg, *chrVec);
@@ -83,7 +83,7 @@ void SomaticHaplotagProcess::pipelineProcess()
         std::time_t begin = time(NULL);
         vcfParser.setCommandLine(sParams.basic.bamCfg.command);
         vcfParser.setVersion(sParams.basic.bamCfg.version);
-        vcfParser.writingResultVCF(sParams.tumorSnpFile, vcfSet[Genome::TUMOR], *chrMultiVariants, sParams.basic.bamCfg.resultPrefix);
+        vcfParser.writingResultVCF(sParams.tumorSnvFile, vcfSet[Genome::TUMOR], *chrMultiVariants, sParams.basic.bamCfg.resultPrefix);
         std::cerr<< difftime(time(NULL), begin) << "s\n";
     }
 
@@ -97,7 +97,6 @@ void SomaticHaplotagProcess::pipelineProcess()
         // somaticBenchmark.displayBedRegionCount(*chrVec);
     }
 
-    return;
     // tag read
     tagRead(sParams.basic, sParams.tumorBamFile, tagSample);
 
@@ -114,11 +113,11 @@ void SomaticHaplotagProcess::parseVariantFiles(VcfParser& vcfParser){
     HaplotagProcess::parseVariantFiles(vcfParser);
 
     //load tumor snp vcf
-    if(sParams.tumorSnpFile != ""){
+    if(sParams.tumorSnvFile != ""){
         std::time_t begin = time(NULL);
         std::cerr<< "parsing tumor SNP VCF ... ";
         vcfParser.setParseSnpFile(true);
-        vcfParser.parsingVCF(sParams.tumorSnpFile, vcfSet[Genome::TUMOR], *chrMultiVariants);
+        vcfParser.parsingVCF(sParams.tumorSnvFile, vcfSet[Genome::TUMOR], *chrMultiVariants);
         vcfParser.reset();
         std::cerr<< difftime(time(NULL), begin) << "s\n";
     }
@@ -581,7 +580,7 @@ void SomaticHaplotagCigarParser::processDeletionOperation(int& length, uint32_t*
 
 void SomaticTagLog::addParamsMessage(){
     *tagReadLog << "##normalSnpFile:" << sParams.basic.snpFile << "\n"
-                << "##tumorSnpFile:" << sParams.tumorSnpFile << "\n"
+                << "##tumorSnvFile:" << sParams.tumorSnvFile << "\n"
                 << "##svFile:" << sParams.basic.svFile << "\n"
                 << "##tumorBamFile:" << sParams.tumorBamFile << "\n"
                 << "##bamFile:" << sParams.basic.bamFile << "\n"

--- a/src/somatic_haplotag/SomaticHaplotagProcess.h
+++ b/src/somatic_haplotag/SomaticHaplotagProcess.h
@@ -50,7 +50,7 @@ class SomaticHaplotagCigarParser: public CigarParser{
         SomaticHaplotagStrategy somaticJudger;
     protected:
 
-        void processMatchOperation(int& length, uint32_t* cigar, int& i, int& aln_core_n_cigar, std::string& base) override;
+        void processMatchOperation(int& length, uint32_t* cigar, int& i, int& aln_core_n_cigar, std::string& base, bool& isAlt, int& offset) override;
         void processDeletionOperation(int& length, uint32_t* cigar, int& i, int& aln_core_n_cigar, bool& alreadyJudgeDel) override;
     public:
         SomaticHaplotagCigarParser(

--- a/src/somatic_haplotag/SomaticHaplotagProcess.h
+++ b/src/somatic_haplotag/SomaticHaplotagProcess.h
@@ -13,7 +13,7 @@ struct SomaticHaplotagParameters
 {
     HaplotagParameters basic;
     // Somatic haplotag parameters
-    std::string tumorSnpFile;   
+    std::string tumorSnvFile;   
     std::string tumorBamFile;  
 
     // somatic benchmark parameters

--- a/src/somatic_haplotag/SomaticVarCaller.cpp
+++ b/src/somatic_haplotag/SomaticVarCaller.cpp
@@ -1592,7 +1592,7 @@ void SomaticVarCaller::writeSomaticVarCallingLog(const CallerContext &ctx, const
                  << "#   Somatic Variants Calling Log   #\n"
                  << "####################################\n";
     (*tagHP3Log) << "##normalSnpFile:"       << ctx.normalSnpFile                    << "\n"
-                 << "##tumorSnpFile:"        << ctx.tumorSnpFile                     << "\n" 
+                 << "##tumorSnvFile:"        << ctx.tumorSnvFile                     << "\n" 
                  << "##bamFile:"             << ctx.normalBamFile                    << "\n"
                  << "##tumorBamFile:"        << ctx.tumorBamFile                     << "\n" 
                  << "##resultPrefix:"        << bamCfg.resultPrefix        << "\n"

--- a/src/somatic_haplotag/SomaticVarCaller.h
+++ b/src/somatic_haplotag/SomaticVarCaller.h
@@ -19,10 +19,10 @@ struct CallerContext
     std::string normalBamFile;
     std::string tumorBamFile;
     std::string normalSnpFile;
-    std::string tumorSnpFile;
+    std::string tumorSnvFile;
     std::string fastaFile;
-    CallerContext(std::string normalBamFile, std::string tumorBamFile, std::string normalSnpFile, std::string tumorSnpFile, std::string fastaFile)
-    :normalBamFile(normalBamFile), tumorBamFile(tumorBamFile), normalSnpFile(normalSnpFile), tumorSnpFile(tumorSnpFile), fastaFile(fastaFile){}
+    CallerContext(std::string normalBamFile, std::string tumorBamFile, std::string normalSnpFile, std::string tumorSnvFile, std::string fastaFile)
+    :normalBamFile(normalBamFile), tumorBamFile(tumorBamFile), normalSnpFile(normalSnpFile), tumorSnvFile(tumorSnvFile), fastaFile(fastaFile){}
 };
 
 /**


### PR DESCRIPTION
feat(somatic-tagging): add INDEL-aware calling and integrate into tagging

- Parse tumor short INDELs (<=100bp) from VCF and include in processing
- Skip long tumor INDELs (>100bp) for stability and performance
- Add SomaticHaplotagCigarParser to handle match/deletion ops and record events
- Track deletion counts and nearby allele-offset bases around variant windows
- Extend tumor/normal data extraction to count bases and deletions at somatic sites
- Compute VAF and MPQ-VAF for SNP/INDEL; add deletion ratio and HP counts
- Classify somatic reads and summarize case ratios at somatic loci
- Write result VCF including insertion/deletion variants with somatic filters
- Display tumor insert/delete counts in pipeline logs
- Keep germline-only tagging behavior unchanged